### PR TITLE
Changed `INFLUX_PSWD` to standard `INFLUX_PASSWORD`

### DIFF
--- a/playbooks/vars/telegraf_dbconnection_vars.yml
+++ b/playbooks/vars/telegraf_dbconnection_vars.yml
@@ -2,4 +2,4 @@ telegraf_influxdb_urls:
   - https://influx1.eco.tsi-dev.otc-service.com:8086
 telegraf_influxdb_database: csm
 telegraf_influxdb_username: csm
-telegraf_influxdb_password: "{{ lookup('env', 'INFLUX_PSWD') }}"
+telegraf_influxdb_password: "{{ lookup('env', 'INFLUX_PASSWORD') }}"

--- a/scenarios/build.sh
+++ b/scenarios/build.sh
@@ -8,7 +8,7 @@ if [[ -z ${scenario_name} ]]; then
     exit 2
 fi
 
-if [[ -z "${INFLUX_PSWD}" ]]; then
+if [[ -z "${INFLUX_PASSWORD}" ]]; then
     echo "InfluxDB password is missing"
     exit 2
 fi


### PR DESCRIPTION
Fix #154

CSM using non-standard `INFLUX_PSWD` variable while AWX is using standard for influx `INFLUX_PASSWORD`