### PR TITLE
Add boto3 to ignored modules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -269,7 +269,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=boto3
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work


### PR DESCRIPTION
Fix false-positives for pylint `no-member` warning for boto3 classes

See: https://github.com/PyCQA/pylint/issues/3134