### PR TITLE
Make `terraform-lint` job to use tox

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,14 +8,10 @@
 
 - job:
     name: terraform-lint
-    parent: simpleton
+    parent: otc-tox
     voting: false
     vars:
-      simple_source_image: "ubuntu:latest"
-      simple_prerun:
-        - sh ./scripts/prepare-terraform.sh
-      simple_run:
-        - sh ./scripts/terraform-lint.sh
+      tox_envlist: tflint
 
 - job:
     name: tox-cover-docker

--- a/scripts/prepare-terraform.sh
+++ b/scripts/prepare-terraform.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/bash
-apt update -y || exit 2
-apt install -y curl unzip || exit 2
-curl https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_linux_amd64.zip -o terraform_0.14.2_linux_amd64.zip || exit 2
-unzip terraform_0.14.2_linux_amd64.zip -d /usr/local/bin || exit 2
+echo "TF version: $1"
+echo "Output path: $2"
+
+local_zip="$2/terraform_$1_linux_amd64.zip"
+local_exec="$2/terraform"
+
+if [[ -f "$local_exec" ]]; then
+  exit 0
+fi
+
+if [[ ! -f "$local_zip" ]]; then
+  curl "https://releases.hashicorp.com/terraform/$1/terraform_$1_linux_amd64.zip" -o "$local_zip"
+fi
+
+unzip "$local_zip" -d "$2"

--- a/scripts/terraform-lint.sh
+++ b/scripts/terraform-lint.sh
@@ -5,7 +5,7 @@ terraform fmt -check -recursive "$scenarios_path" || exit 1
 
 function check {
   echo "Checking $1"
-  terraform init --backend=false --input=false "$1" >/dev/null || return 2
+  terraform init --backend=false --input=false --no-color "$1" >/dev/null || return 2
   echo "Successfully Initialized"
   terraform validate || return 2
 }

--- a/scripts/terraform-lint.sh
+++ b/scripts/terraform-lint.sh
@@ -5,7 +5,7 @@ terraform fmt -check -recursive "$scenarios_path" || exit 1
 
 function check {
   echo "Checking $1"
-  terraform init --backend=false --input=false --no-color "$1" >/dev/null || return 2
+  terraform init -backend=false -input=false -no-color "$1" >/dev/null || return 2
   echo "Successfully Initialized"
   terraform validate || return 2
 }

--- a/scripts/terraform-lint.sh
+++ b/scripts/terraform-lint.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/bash
-scenarios_path="$(pwd)/scenarios"
+scenarios_path="$PWD/scenarios"
 
 terraform fmt -check -recursive "$scenarios_path" || exit 1
 
-function check() {
-  cd "$1" || return 2
+function check {
   echo "Checking $1"
-  terraform init --backend=false --input=false > /dev/null || return 2
+  terraform init --backend=false --input=false "$1" >/dev/null || return 2
   echo "Successfully Initialized"
   terraform validate || return 2
 }

--- a/tox.ini
+++ b/tox.ini
@@ -63,10 +63,10 @@ deps =
 
 setenv =
     PATH = {env:PATH}{:}{toxinidir}
+    TF_VERSION = 0.14.3
 
 commands_pre =
-    /usr/bin/curl https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_linux_amd64.zip -o terraform_0.14.2_linux_amd64.zip
-    /usr/bin/unzip terraform_0.14.2_linux_amd64.zip -d {toxinidir}
+    /usr/bin/bash {toxinidir}/scripts/prepare-terraform.sh {env:TF_VERSION} {toxinidir}
 
 commands =
     /usr/bin/bash {toxinidir}/scripts/terraform-lint.sh

--- a/tox.ini
+++ b/tox.ini
@@ -57,3 +57,16 @@ commands =
 [flake8]
 ignore = I201, I100
 max-line-length = 99
+
+[testenv:tflint]
+deps =
+
+setenv =
+    PATH = {env:PATH}{:}{toxinidir}
+
+commands_pre =
+    /usr/bin/curl https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_linux_amd64.zip -o terraform_0.14.2_linux_amd64.zip
+    /usr/bin/unzip terraform_0.14.2_linux_amd64.zip -d {toxinidir}
+
+commands =
+    /usr/bin/bash {toxinidir}/scripts/terraform-lint.sh


### PR DESCRIPTION
Currently, `terraform-lint` works incorrectly. `terraform-lint.sh` is run using `sh`, but expected to use `bash`.
Also, tox seems to be an easier and cleaner solution in this case.

Fixes problem noted in #302