### PR TITLE
Fix incorrect terraform validate call

### DIFF
--- a/scripts/terraform-lint.sh
+++ b/scripts/terraform-lint.sh
@@ -4,8 +4,9 @@ scenarios_path="$PWD/scenarios"
 terraform fmt -check -recursive "$scenarios_path" || exit 1
 
 function check {
+  cd "$1" || return 2
   echo "Checking $1"
-  terraform init -backend=false -input=false -no-color "$1" >/dev/null || return 2
+  terraform init -backend=false -input=false -no-color >/dev/null || return 2
   echo "Successfully Initialized"
   terraform validate || return 2
 }


### PR DESCRIPTION
`terraform validate` was called without specifying path