### PR TITLE
Fix rds backup monitoring

### DIFF
--- a/playbooks/rds_backup_monitoring_setup.yml
+++ b/playbooks/rds_backup_monitoring_setup.yml
@@ -198,6 +198,7 @@
   vars:
     cloud_config: "/etc/openstack"
     endpoint: "https://rds.eu-de.otc.t-systems.com"
+    ecs_instance_ip: "{{ hostvars.test_host.ecs_instance_ip }}"
   tasks:
     - name: Copy clouds.yaml to ecs
       copy:


### PR DESCRIPTION
Fix missing `ecs_instance_ip` var in RDS backup monitoring