### PR TITLE
Backward compatibility fix for telegraf client role

### DIFF
--- a/roles/telegraf-client
+++ b/roles/telegraf-client
@@ -1,0 +1,1 @@
+telegraf_client


### PR DESCRIPTION
Add `telegraf-client` link to `telegraf_client`