### PR TITLE
Fix destruction order of `csm_controller`

### DIFF
--- a/scenarios/csm_controller/infrastructure.tf
+++ b/scenarios/csm_controller/infrastructure.tf
@@ -34,6 +34,10 @@ module "bastion" {
 
   availability_zone = var.availability_zone
   bastion_eip       = local.controller_eip
+
+  depends_on = [
+    module.network
+  ]
 }
 
 output "csm_controller_fip" {


### PR DESCRIPTION
Fix #325 