### PR TITLE
Use `tox-linters-ansible-2.9` and `tox-linters-ansible-2.10` jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,11 +1,5 @@
 ---
 - job:
-    name: ansible-lint
-    parent: otc-tox
-    vars:
-      tox_envlist: yamllint
-
-- job:
     name: terraform-lint
     parent: otc-tox
     vars:
@@ -23,7 +17,8 @@
       jobs:
         - terraform-lint
         - otc-tox-pep8
-        - ansible-lint
+        - tox-linters-ansible-2.9
+        - tox-linters-ansible-2.10
         - tox-cover-docker
         - tox-molecule-29
         - tox-molecule-210
@@ -31,7 +26,8 @@
       jobs:
         - terraform-lint
         - otc-tox-pep8
-        - ansible-lint
+        - tox-linters-ansible-2.9
+        - tox-linters-ansible-2.10
         - tox-cover-docker
         - tox-molecule-29
         - tox-molecule-210

--- a/scripts/ansible-lint.sh
+++ b/scripts/ansible-lint.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 find ./playbooks/ -name "*.yml" -not -path "*/templates/*" -exec ansible-lint --nocolor {} +

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
 
 commands =
     yamllint . -f parsable
-    /usr/bin/bash {toxinidir}/scripts/ansible-lint.sh
+    {toxinidir}/scripts/ansible-lint.sh
 
 [flake8]
 ignore = I201, I100

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,8 @@ ignore_errors = true
 whitelist_externals = sh
 
 deps =
-    {[testenv]deps}
+    ansible-lint
+    29: ansible>=2.9,<2.10
     yamllint==1.25.0
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.1
-envlist = py37,py38,pep8,molecule-ansible{29,210}
+envlist = py37,py38,pep8,molecule-ansible{29,210},linters{,-29}
 skipsdist = True
 
 [testenv]
@@ -42,7 +42,7 @@ commands =
 deps =
     -r{toxinidir}/lint-requirements.txt
 
-[testenv:yamllint]
+[testenv:linters{,-29}]
 ignore_errors = true
 whitelist_externals = sh
 


### PR DESCRIPTION
Move to more stable jobs with wider coverage

Depends-on: https://github.com/opentelekomcloud-infra/otc-zuul-jobs/pull/37