### PR TITLE
Move `tox-cover-docker` onto `debian-buster` node

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,7 +8,7 @@
 - job:
     name: tox-cover-docker
     parent: tox-cover
-    nodeset: ubuntu-focal
+    nodeset: debian-buster
     pre-run: ./tests/docker/pre.yaml
 
 - project:


### PR DESCRIPTION
Zuul `ubuntu-focal` machine starting too slow