### PR TITLE
Get rid of telegraf-client symlink

### DIFF
--- a/playbooks/as_monitoring_setup.yml
+++ b/playbooks/as_monitoring_setup.yml
@@ -139,7 +139,7 @@
   vars_files:
     - "./vars/telegraf_dbconnection_vars.yml"
   roles:
-    - role: telegraf-client
+    - role: telegraf_client
       vars:
         telegraf_influxdb_retention_policy: ""
         telegraf_plugins_base:

--- a/playbooks/dns_monitoring_setup.yml
+++ b/playbooks/dns_monitoring_setup.yml
@@ -70,7 +70,7 @@
     - "./vars/telegraf_dbconnection_vars.yml"
     - "./vars/nginx_telegraf_local.yml"
   roles:
-    - role: telegraf-client
+    - role: telegraf_client
       vars:
         telegraf_influxdb_retention_policy: ""
         telegraf_plugins_base:

--- a/playbooks/hdd_monitoring_setup.yml
+++ b/playbooks/hdd_monitoring_setup.yml
@@ -103,7 +103,7 @@
   vars_files:
     - "./vars/telegraf_dbconnection_vars.yml"
   roles:
-    - telegraf-client
+    - telegraf_client
   vars:
     telegraf_influxdb_retention_policy: ""
     telegraf_plugins_base:

--- a/playbooks/iscsi_monitoring_setup.yml
+++ b/playbooks/iscsi_monitoring_setup.yml
@@ -148,7 +148,7 @@
     - "./vars/telegraf_dbconnection_vars.yml"
     - "./vars/scenario_iscsi_vars.yml"
   roles:
-    - telegraf-client
+    - telegraf_client
   vars:
     telegraf_influxdb_retention_policy: ""
     telegraf_plugins_base:

--- a/playbooks/lb_down_monitoring_setup.yml
+++ b/playbooks/lb_down_monitoring_setup.yml
@@ -99,7 +99,7 @@
         executable: pip3
         name: csm-test-utils
   roles:
-    - role: telegraf-client
+    - role: telegraf_client
       vars:
         telegraf_influxdb_retention_policy: ""
         telegraf_plugins_base:

--- a/playbooks/lb_monitoring_setup.yml
+++ b/playbooks/lb_monitoring_setup.yml
@@ -79,7 +79,7 @@
     - "./vars/telegraf_dbconnection_vars.yml"
     - "./vars/nginx_telegraf_local.yml"
   roles:
-    - role: telegraf-client
+    - role: telegraf_client
       vars:
         telegraf_influxdb_retention_policy: ""
         telegraf_plugins_base:
@@ -101,7 +101,7 @@
   vars_files:
     - "./vars/telegraf_dbconnection_vars.yml"
   roles:
-    - telegraf-client
+    - telegraf_client
   vars:
     telegraf_influxdb_retention_policy: ""
     telegraf_plugins_base:

--- a/playbooks/rds_backup_monitoring_setup.yml
+++ b/playbooks/rds_backup_monitoring_setup.yml
@@ -142,7 +142,7 @@
   vars_files:
     - "./vars/telegraf_dbconnection_vars.yml"
   roles:
-    - role: telegraf-client
+    - role: telegraf_client
       vars:
         telegraf_influxdb_retention_policy: ""
         telegraf_local_port: 8080

--- a/playbooks/rds_monitoring_setup.yml
+++ b/playbooks/rds_monitoring_setup.yml
@@ -77,7 +77,7 @@
   vars_files:
     - "./vars/telegraf_dbconnection_vars.yml"
   roles:
-    - role: telegraf-client
+    - role: telegraf_client
       vars:
         telegraf_influxdb_retention_policy: ""
         telegraf_local_port: 8080

--- a/playbooks/setup_telegraf_local.yml
+++ b/playbooks/setup_telegraf_local.yml
@@ -6,7 +6,7 @@
     - "./vars/telegraf_dbconnection_vars.yml"
     - "./vars/nginx_telegraf_local.yml"
   roles:
-    - role: telegraf-client
+    - role: telegraf_client
       vars:
         telegraf_plugins_base:
           - name: http_listener_v2

--- a/playbooks/sfs_monitoring_setup.yml
+++ b/playbooks/sfs_monitoring_setup.yml
@@ -125,7 +125,7 @@
   vars_files:
     - "./vars/telegraf_dbconnection_vars.yml"
   roles:
-    - telegraf-client
+    - telegraf_client
   vars:
     telegraf_influxdb_retention_policy: ""
     telegraf_plugins_base:

--- a/roles/telegraf-client
+++ b/roles/telegraf-client
@@ -1,1 +1,0 @@
-telegraf_client


### PR DESCRIPTION
Using `telegraf-client` symlink was a temporary solution