### PR TITLE
Fix setting private key permissions

### DIFF
--- a/playbooks/lb_down_monitoring_setup.yml
+++ b/playbooks/lb_down_monitoring_setup.yml
@@ -20,7 +20,6 @@
         lb_down_instance_ip: "{{ tf_output.outputs['lb_down_instance_fip'].value }}"
         lb_down_node_ips: "{{ tf_output.outputs['lb_down_ecs_ips'].value }}"
         lb_control_instance_ip: "{{ tf_output.outputs['lb_ctrl_ip'].value }}"
-        key_name: "{{ key_name }}"
         local_private_key: "{{ local_private_key }}"
     - name: Register controller node
       add_host:

--- a/playbooks/rds_monitoring_server_stop.yml
+++ b/playbooks/rds_monitoring_server_stop.yml
@@ -3,7 +3,6 @@
   hosts: test_host
   vars:
     ecs_instance_ip: "192.168.8.10"
-    key_name: key_csm_controller
   tasks:
     - name: Register ecs
       add_host:

--- a/playbooks/setup_scenarios_controller.yml
+++ b/playbooks/setup_scenarios_controller.yml
@@ -23,8 +23,12 @@
       fetch:
         src: "{{ tmp_dir }}/{{ key_name }}"
         dest: "{{ local_private_key }}"
-        mode: 0600
         flat: yes
+
+    - name: Change mode of private key to 0o600
+      file:
+        path: "{{ local_private_key }}"
+        mode: 0600
 
     - name: Register csm_controller
       add_host:


### PR DESCRIPTION
Ansible `fetch` does not support setting mode: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fetch_module.html.

Set mod `0600` for private key file via `file` module.

Remove redundant `key_name` variables.