### PR TITLE
Pass terraform variables directly

### DIFF
--- a/playbooks/as_monitoring_destroy.yaml
+++ b/playbooks/as_monitoring_destroy.yaml
@@ -4,10 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: as_monitoring
     infra_state: absent

--- a/playbooks/as_monitoring_setup.yaml
+++ b/playbooks/as_monitoring_setup.yaml
@@ -4,14 +4,14 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
-    TF_VAR_controller_ip: "{{ controller_public_ip }}"
   vars:
     scenario_name: as_monitoring
     infra_state: present
+    terraform_variables:
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
+      controller_ip: "{{ controller_public_ip }}"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/dns_monitoring_destroy.yaml
+++ b/playbooks/dns_monitoring_destroy.yaml
@@ -4,10 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: dns_monitoring
     infra_state: absent

--- a/playbooks/dns_monitoring_setup.yaml
+++ b/playbooks/dns_monitoring_setup.yaml
@@ -4,13 +4,13 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: dns_monitoring
     infra_state: present
+    terraform_variables:
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/hdd_monitoring_destroy.yaml
+++ b/playbooks/hdd_monitoring_destroy.yaml
@@ -4,10 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: hdd_monitoring
     infra_state: absent

--- a/playbooks/hdd_monitoring_setup.yaml
+++ b/playbooks/hdd_monitoring_setup.yaml
@@ -4,14 +4,14 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_cidr: "{{ terraform_network_cidr }}"
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: hdd_monitoring
     infra_state: present
+    terraform_variables:
+      network_cidr: "{{ terraform_network_cidr }}"
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/iscsi_monitoring_destroy.yaml
+++ b/playbooks/iscsi_monitoring_destroy.yaml
@@ -4,10 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: iscsi_monitoring
     infra_state: absent

--- a/playbooks/iscsi_monitoring_setup.yaml
+++ b/playbooks/iscsi_monitoring_setup.yaml
@@ -4,14 +4,14 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_cidr: "{{ terraform_network_cidr }}"
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: iscsi_monitoring
     infra_state: present
+    terraform_variables:
+      network_cidr: "{{ terraform_network_cidr }}"
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/lb_down_monitoring_destroy.yaml
+++ b/playbooks/lb_down_monitoring_destroy.yaml
@@ -4,10 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: lb_down_monitoring
     infra_state: absent

--- a/playbooks/lb_down_monitoring_setup.yaml
+++ b/playbooks/lb_down_monitoring_setup.yaml
@@ -4,14 +4,14 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_cidr: "{{ terraform_network_cidr }}"
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: lb_down_monitoring
     infra_state: present
+    terraform_variables:
+      network_cidr: "{{ terraform_network_cidr }}"
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/lb_monitoring_destroy.yaml
+++ b/playbooks/lb_monitoring_destroy.yaml
@@ -4,10 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: lb_monitoring
     infra_state: absent

--- a/playbooks/lb_monitoring_setup.yaml
+++ b/playbooks/lb_monitoring_setup.yaml
@@ -4,14 +4,14 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_cidr: "{{ terraform_network_cidr }}"
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: lb_monitoring
     infra_state: present
+    terraform_variables:
+      network_cidr: "{{ terraform_network_cidr }}"
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/rds_backup_monitoring_destroy.yaml
+++ b/playbooks/rds_backup_monitoring_destroy.yaml
@@ -4,12 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
-    TF_VAR_psql_password: "Spaciba2020!"
-    OS_CLOUD: "{{ lookup('env', 'OS_CLOUD') }}"
   vars:
     scenario_name: rds_backup_monitoring
     infra_state: absent

--- a/playbooks/rds_backup_monitoring_setup.yaml
+++ b/playbooks/rds_backup_monitoring_setup.yaml
@@ -4,15 +4,14 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
-    TF_VAR_controller_ip: "{{ controller_public_ip }}"
-    TF_VAR_psql_password: "Spaciba2020!"
   vars:
     scenario_name: rds_backup_monitoring
     infra_state: present
+    terraform_variables:
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
+      psql_password: "Spaciba2020!"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/rds_monitoring_destroy.yaml
+++ b/playbooks/rds_monitoring_destroy.yaml
@@ -4,12 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
-    TF_VAR_subnet_cidr: "{{ main_subnet_cidr }}"
-    TF_VAR_psql_password: "Spaciba2020!"
   vars:
     scenario_name: rds_monitoring
     infra_state: absent

--- a/playbooks/rds_monitoring_setup.yaml
+++ b/playbooks/rds_monitoring_setup.yaml
@@ -4,15 +4,15 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_cidr: "{{ terraform_network_cidr }}"
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
-    TF_VAR_psql_password: "Spaciba2020!"
   vars:
     scenario_name: rds_monitoring
     infra_state: present
+    terraform_variables:
+      network_cidr: "{{ terraform_network_cidr }}"
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
+      psql_password: "Spaciba2020!"
   roles:
     - build_infrastructure
   tasks:

--- a/playbooks/sfs_monitoring_destroy.yaml
+++ b/playbooks/sfs_monitoring_destroy.yaml
@@ -4,10 +4,6 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: sfs_monitoring
     infra_state: absent

--- a/playbooks/sfs_monitoring_setup.yaml
+++ b/playbooks/sfs_monitoring_setup.yaml
@@ -4,15 +4,14 @@
 
 - name: Prepare variables
   hosts: local
-  environment:
-    TF_VAR_network_id: "{{ main_network_id }}"
-    TF_VAR_router_id: "{{ main_router_id }}"
-    TF_VAR_subnet_id: "{{ main_subnet_id }}"
   vars:
     scenario_name: sfs_monitoring
     infra_state: present
     terraform_variables:
       kms_key: "{{ kms_key }}"
+      network_id: "{{ main_network_id }}"
+      router_id: "{{ main_router_id }}"
+      subnet_id: "{{ main_subnet_id }}"
   roles:
     - build_infrastructure
   tasks:

--- a/roles/build_infrastructure/defaults/main.yaml
+++ b/roles/build_infrastructure/defaults/main.yaml
@@ -15,3 +15,7 @@ aws_credential:
   secret: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
   access: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
   token: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+
+terraform_plugin_dir: "{{ lookup('env','HOME') }}/.terraform.d/plugin-cache"
+
+terraform_variables: {}

--- a/roles/build_infrastructure/tasks/build.yaml
+++ b/roles/build_infrastructure/tasks/build.yaml
@@ -6,4 +6,5 @@
     force_init: true
     project_path: "{{ terraform_remote_dir }}/{{ scenario_name }}"
     backend_config: "{{ backend_config }}"
+    variables: "{{ terraform_variables }}"
   register: tf_output

--- a/roles/build_infrastructure/tasks/pre_build.yaml
+++ b/roles/build_infrastructure/tasks/pre_build.yaml
@@ -1,17 +1,28 @@
 ---
+- name: Prepare Terraform plugin cache dir
+  file:
+    path: "{{ terraform_plugin_dir }}"
+    state: directory
+
+- name: Prepare tmp dir
+  file:
+    path: "{{ tmp_dir }}"
+    state: directory
+
 - name: Copy Requirements
   copy:
     src: "{{ requirements }}"
     dest: "{{ tmp_dir }}"
+
 - name: Archive terraform setup
   archive:
-    dest: "{{ terraform_base_dir }}.tgz"
+    dest: "{{ terraform_base_dir }}.tar"
     path: "{{ terraform_base_dir }}"
-    exclude_path: ".terraform"
+    format: tar
   delegate_to: localhost
 - name: Unarchive terraform setup on remote
   unarchive:
-    src: "{{ terraform_base_dir }}.tgz"
+    src: "{{ terraform_base_dir }}.tar"
     dest: "{{ tmp_dir }}"
     keep_newer: yes
 - name: Install master requirements

--- a/roles/build_infrastructure/vars/main.yaml
+++ b/roles/build_infrastructure/vars/main.yaml
@@ -9,6 +9,7 @@ backend_config:
   region: "eu-de"
 
 default_variables:
+  TF_PLUGIN_CACHE_DIR: "{{ terraform_plugin_dir }}"
   AWS_SECRET_ACCESS_KEY: "{{ aws_credential.secret }}"
   AWS_ACCESS_KEY_ID: "{{ aws_credential.access }}"
   AWS_SESSION_TOKEN: "{{ aws_credential.token }}"
@@ -16,4 +17,4 @@ default_variables:
   OS_CLIENT_CONFIG_FILE: "{{ os_cloud_config_file }}"
   TF_VAR_availability_zone: "eu-de-03"
   TF_VAR_ecs_flavor: "s2.medium.2"
-  TF_VAR_ecs_image: "Debian_10_latest"
+  TF_VAR_ecs_image: "Standard_Debian_10_latest"


### PR DESCRIPTION
Instead of passing terraform variables as env variables,
pass them to `terraform` module as `variables` (`terraform_variables`)

Use `TF_PLUGIN_CACHE_DIR` (`terraform_plugin_dir`)

Use `tar` archive instead of `tgz` for copying terraform configurations