### PR TITLE
Remove `bastion_setup` from destroy playbooks

### DIFF
--- a/playbooks/as_monitoring_destroy.yaml
+++ b/playbooks/as_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/dns_monitoring_destroy.yaml
+++ b/playbooks/dns_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/hdd_monitoring_destroy.yaml
+++ b/playbooks/hdd_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/iscsi_monitoring_destroy.yaml
+++ b/playbooks/iscsi_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/lb_down_monitoring_destroy.yaml
+++ b/playbooks/lb_down_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/lb_monitoring_destroy.yaml
+++ b/playbooks/lb_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/rds_backup_monitoring_destroy.yaml
+++ b/playbooks/rds_backup_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/rds_monitoring_destroy.yaml
+++ b/playbooks/rds_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:

--- a/playbooks/sfs_monitoring_destroy.yaml
+++ b/playbooks/sfs_monitoring_destroy.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Prepare controller variables
-  import_playbook: bastion_setup.yaml
-
 - name: Prepare variables
   hosts: local
   vars:


### PR DESCRIPTION
Running `bastion_setup.yaml` is redundant  for `destroy` playbooks