### PR TITLE
Make `ansible-lint` dependency more strict

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 ignore_errors = true
 
 deps =
-    ansible-lint
+    ansible-lint>=4.3,<5
     29: ansible>=2.9,<2.10
     yamllint==1.25.0
 


### PR DESCRIPTION
`ansible-lint` 5.0+ detects unexpected warning and errors:
```
2021-02-10 01:54:06.649848 | fedora-pod | Loading custom .yamllint config file, this extends our internal yamllint config.
2021-02-10 01:54:06.680973 | fedora-pod | WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: ./playbooks/files/lb_down/lb_down_monitoring_start_server.yaml
2021-02-10 01:54:06.683344 | fedora-pod | WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: ./playbooks/files/lb_down/lb_down_monitoring_stop_server_on_random_node.yaml
2021-02-10 01:54:10.280600 | fedora-pod | WARNING  Listing 2 violation(s) that are fatal
2021-02-10 01:54:10.281727 | fedora-pod | internal-error playbooks/bastion_setup.yaml:9:7
2021-02-10 01:54:10.282064 | fedora-pod | syntax-check playbooks/files/lb_down/lb_down_monitoring_stop_server_on_random_node.yaml:2:3
2021-02-10 01:54:10.282246 | fedora-pod | WARNING  Replaced deprecated tag '106' with 'role-name' but it will become an error in the future.
2021-02-10 01:54:10.282280 | fedora-pod | WARNING  Replaced deprecated tag '208' with 'risky-file-permissions' but it will become an error in the future.
```